### PR TITLE
Correct anchor link for {{each .. in ..}}

### DIFF
--- a/site/source/guide/spacebars.md
+++ b/site/source/guide/spacebars.md
@@ -210,7 +210,7 @@ Note that `name` and `color` (and `todo` above) are only added to scope in the t
 
 ### Each and With
 
-There are also two Spacebars built-in helpers, `{% raw %}{{#each}}{% endraw %}`, and `{% raw %}{{#with}}{% endraw %}`, which we do not recommend using (see [use each-in](../guide/spacebars.html#each-in) below). These block helpers change the data context within a template, which can be difficult to reason about.
+There are also two Spacebars built-in helpers, `{% raw %}{{#each}}{% endraw %}`, and `{% raw %}{{#with}}{% endraw %}`, which we do not recommend using (see [prefer using each-in](../guide/reusable-components.html#Prefer-lt-￼16-gt)). These block helpers change the data context within a template, which can be difficult to reason about.
 
 Like `{% raw %}{{#each .. in}}{% endraw %}`, `{% raw %}{{#each}}{% endraw %}` iterates over an array or cursor, changing the data context within its content block to be the item in the current iteration. `{% raw %}{{#with}}{% endraw %}` simply changes the data context inside itself to the provided object. In most cases it's better to use `{% raw %}{{#each .. in}}{% endraw %}` and `{% raw %}{{#let}}{% endraw %}` instead, just like it's better to declare a variable than use the JavaScript `with` keyword.
 


### PR DESCRIPTION
~~Hey! A link was broken from spacebars to the benefits of each .. in.~~

edit: epic fail PR :octocat: 
